### PR TITLE
Switch lombok's non-null implementation to JDK

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -2,4 +2,4 @@
 config.stopBubbling=true
 lombok.addLombokGeneratedAnnotation=true
 lombok.anyConstructor.addConstructorProperties=true
-lombok.nonNull.exceptionType=IllegalArgumentException
+lombok.nonNull.exceptionType=JDK


### PR DESCRIPTION
helps with coverage and is the idiomatic way of parameter null checking in java